### PR TITLE
docs: Fix broken URL in the "Wallet Connect (Reown)" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ Biconomy provides Account Abstraction APIs for a wide range of uses cases and po
 [Biconomy Documentation](https://docs.biconomy.io/)
 #### Wallet Connect (Reown):
 Wallet Connect is an easy way to get started with wallet integration across web3.\
-[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-appshttps://t.me/appkit_test_ggr_bot)\
+[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-apps)\
 [Reown Docs](https://docs.reown.com/)


### PR DESCRIPTION
I noticed an issue in the "Wallet Connect (Reown)" section where the link for "Wallet Connect for Telegram Mini Apps" had a formatting problem.

<img width="1003" alt="Снимок экрана 2024-12-23 в 22 40 57" src="https://github.com/user-attachments/assets/da9122c0-d674-43be-ac6c-8cbde63a1340" />

The URL was malformed and combined two separate links. I've corrected the URL to point to the right location:

```
[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-apps)
```

