### PR TITLE
Fix synax error in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ Biconomy provides Account Abstraction APIs for a wide range of uses cases and po
 [Biconomy Documentation](https://docs.biconomy.io/)
 #### Wallet Connect (Reown):
 Wallet Connect is an easy way to get started with wallet integration across web3.\
-[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-apps) and [Telegram appkit_test_ggr_bot](https://t.me/appkit_test_ggr_bot)\
+[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-apps) and [Telegram AppKit bot](https://t.me/appkit_test_ggr_bot)\
 [Reown Docs](https://docs.reown.com)\

--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ Biconomy provides Account Abstraction APIs for a wide range of uses cases and po
 [Biconomy Documentation](https://docs.biconomy.io/)
 #### Wallet Connect (Reown):
 Wallet Connect is an easy way to get started with wallet integration across web3.\
-[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-appshttps://t.me/appkit_test_ggr_bot)\
-[Reown Docs](https://docs.reown.com/)
+[Wallet Connect for Telegram Mini Apps](https://docs.reown.com/appkit/features/telegram-mini-apps) and [Telegram appkit_test_ggr_bot](https://t.me/appkit_test_ggr_bot)\
+[Reown Docs](https://docs.reown.com)\


### PR DESCRIPTION
In the original fragment, two separate links were merged together without a space or separator, making both links invalid.
If the error is not corrected, both links will be non-functional, and users will be unable to access the corresponding resources.